### PR TITLE
Feat/#71 데이터 스토어 암호화

### DIFF
--- a/app/src/main/java/com/hara/kaera/application/Constant.kt
+++ b/app/src/main/java/com/hara/kaera/application/Constant.kt
@@ -5,7 +5,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 object Constant {
     const val APPLICATION_JSON = "application/json"
     // dataStore
-    const val TOKEN_DATASTORE_NAME = "token_datastore"
+    const val TOKEN_DATASTORE_NAME = "token_datastore.json"
     const val EMPTY_TOKEN = "token not founded"
     val ACCESS_TOKEN_KEY = stringPreferencesKey("access_token")
     val REFRESH_TOKEN_KEY = stringPreferencesKey("refresh_token")

--- a/app/src/main/java/com/hara/kaera/data/datasource/local/LoginDataStoreSerializer.kt
+++ b/app/src/main/java/com/hara/kaera/data/datasource/local/LoginDataStoreSerializer.kt
@@ -1,0 +1,38 @@
+package com.hara.kaera.data.datasource.local
+
+import androidx.datastore.core.Serializer
+import com.hara.kaera.data.util.CryptoManager
+import com.hara.kaera.domain.entity.login.LoginData
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import java.io.InputStream
+import java.io.OutputStream
+
+class LoginDataStoreSerializer (
+    private val cryptoManager: CryptoManager,
+):Serializer<LoginData> {
+    override val defaultValue: LoginData
+        get() = LoginData()
+
+    override suspend fun readFrom(input: InputStream): LoginData {
+        val decryptedBytes = cryptoManager.decrypt(input)
+        return try {
+            Json.decodeFromString(
+                deserializer = LoginData.serializer(),
+                string = decryptedBytes.decodeToString()
+            )
+        } catch(e: SerializationException) {
+            defaultValue
+        }
+    }
+
+    override suspend fun writeTo(t: LoginData, output: OutputStream) {
+        cryptoManager.encrypt(
+            bytes = Json.encodeToString(
+                serializer = LoginData.serializer(),
+                value = t
+            ).encodeToByteArray(),
+            outputStream = output
+        )
+    }
+}

--- a/app/src/main/java/com/hara/kaera/data/datasource/remote/KaeraApi.kt
+++ b/app/src/main/java/com/hara/kaera/data/datasource/remote/KaeraApi.kt
@@ -2,7 +2,7 @@ package com.hara.kaera.data.datasource.remote
 
 import com.hara.kaera.data.dto.DeleteWorryDTO
 import com.hara.kaera.data.dto.HomeWorryListDTO
-import com.hara.kaera.data.dto.login.KaKaoLoginReqDTO
+import com.hara.kaera.domain.dto.KaKaoLoginReqDTO
 import com.hara.kaera.data.dto.login.KaKaoLoginResDTO
 import com.hara.kaera.data.dto.ReviewReqDTO
 import com.hara.kaera.data.dto.ReviewResDTO

--- a/app/src/main/java/com/hara/kaera/data/datasource/remote/LoginApi.kt
+++ b/app/src/main/java/com/hara/kaera/data/datasource/remote/LoginApi.kt
@@ -1,8 +1,8 @@
 package com.hara.kaera.data.datasource.remote
 
-import com.hara.kaera.data.dto.login.JWTRefreshReqDTO
+import com.hara.kaera.domain.dto.JWTRefreshReqDTO
 import com.hara.kaera.data.dto.login.JWTRefreshResDTO
-import com.hara.kaera.data.dto.login.KaKaoLoginReqDTO
+import com.hara.kaera.domain.dto.KaKaoLoginReqDTO
 import com.hara.kaera.data.dto.login.KaKaoLoginResDTO
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/app/src/main/java/com/hara/kaera/data/datasource/remote/LoginDataSource.kt
+++ b/app/src/main/java/com/hara/kaera/data/datasource/remote/LoginDataSource.kt
@@ -1,8 +1,8 @@
 package com.hara.kaera.data.datasource.remote
 
-import com.hara.kaera.data.dto.login.JWTRefreshReqDTO
+import com.hara.kaera.domain.dto.JWTRefreshReqDTO
 import com.hara.kaera.data.dto.login.JWTRefreshResDTO
-import com.hara.kaera.data.dto.login.KaKaoLoginReqDTO
+import com.hara.kaera.domain.dto.KaKaoLoginReqDTO
 import com.hara.kaera.data.dto.login.KaKaoLoginResDTO
 import kotlinx.coroutines.flow.Flow
 

--- a/app/src/main/java/com/hara/kaera/data/datasource/remote/LoginDataSourceImpl.kt
+++ b/app/src/main/java/com/hara/kaera/data/datasource/remote/LoginDataSourceImpl.kt
@@ -1,8 +1,8 @@
 package com.hara.kaera.data.datasource.remote
 
-import com.hara.kaera.data.dto.login.JWTRefreshReqDTO
+import com.hara.kaera.domain.dto.JWTRefreshReqDTO
 import com.hara.kaera.data.dto.login.JWTRefreshResDTO
-import com.hara.kaera.data.dto.login.KaKaoLoginReqDTO
+import com.hara.kaera.domain.dto.KaKaoLoginReqDTO
 import com.hara.kaera.data.dto.login.KaKaoLoginResDTO
 import com.hara.kaera.data.util.safeCallApi
 import com.hara.kaera.di.ServiceModule

--- a/app/src/main/java/com/hara/kaera/data/repository/LoginRepositoryImpl.kt
+++ b/app/src/main/java/com/hara/kaera/data/repository/LoginRepositoryImpl.kt
@@ -8,8 +8,8 @@ import com.hara.kaera.application.Constant
 import com.hara.kaera.application.Constant.EMPTY_TOKEN
 import com.hara.kaera.core.ApiResult
 import com.hara.kaera.data.datasource.remote.LoginDataSource
-import com.hara.kaera.data.dto.login.JWTRefreshReqDTO
-import com.hara.kaera.data.dto.login.KaKaoLoginReqDTO
+import com.hara.kaera.domain.dto.JWTRefreshReqDTO
+import com.hara.kaera.domain.dto.KaKaoLoginReqDTO
 import com.hara.kaera.data.mapper.LoginMapper
 import com.hara.kaera.domain.entity.login.KakaoLoginJWTEntity
 import com.hara.kaera.domain.repository.LoginRepository

--- a/app/src/main/java/com/hara/kaera/data/util/CrpytoManger.kt
+++ b/app/src/main/java/com/hara/kaera/data/util/CrpytoManger.kt
@@ -2,6 +2,9 @@ package com.hara.kaera.data.util
 
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
+import timber.log.Timber
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.io.OutputStream
 import java.security.KeyStore
@@ -28,7 +31,8 @@ class CryptoManager {
     }
 
     private fun getKey(): SecretKey {
-        val existingKey = keyStore.getEntry("secret", null) as? KeyStore.SecretKeyEntry
+        val existingKey = keyStore.getEntry(ALIAS, null) as? KeyStore.SecretKeyEntry
+        Timber.e(existingKey.toString())
         return existingKey?.secretKey ?: createKey()
     }
 
@@ -36,9 +40,10 @@ class CryptoManager {
         return KeyGenerator.getInstance(ALGORITHM).apply {
             init(
                 KeyGenParameterSpec.Builder(
-                    "secret",
+                    ALIAS,
                     KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
                 )
+                    .setKeySize(KEY_SIZE * 8) // key size in bits
                     .setBlockModes(BLOCK_MODE)
                     .setEncryptionPaddings(PADDING)
                     .setUserAuthenticationRequired(false)
@@ -48,32 +53,57 @@ class CryptoManager {
         }.generateKey()
     }
 
-    fun encrypt(bytes: ByteArray, outputStream: OutputStream): ByteArray {
-        val encryptedBytes = encryptCipher.doFinal(bytes)
+    fun encrypt(bytes: ByteArray, outputStream: OutputStream) {
+        val cipher = encryptCipher
+        val iv = cipher.iv
         outputStream.use {
-            it.write(encryptCipher.iv.size)
-            it.write(encryptCipher.iv)
-            it.write(encryptedBytes.size)
-            it.write(encryptedBytes)
+            it.write(iv)
+            // write the payload in chunks to make sure to support larger data amounts (this would otherwise fail silently and result in corrupted data being read back)
+            ////////////////////////////////////
+            val inputStream = ByteArrayInputStream(bytes)
+            val buffer = ByteArray(CHUNK_SIZE)
+            while (inputStream.available() > CHUNK_SIZE) {
+                inputStream.read(buffer)
+                val ciphertextChunk = cipher.update(buffer)
+                it.write(ciphertextChunk)
+            }
+            // the last chunk must be written using doFinal() because this takes the padding into account
+            val remainingBytes = inputStream.readBytes()
+            val lastChunk = cipher.doFinal(remainingBytes)
+            it.write(lastChunk)
+            //////////////////////////////////
         }
-        return encryptedBytes
     }
 
     fun decrypt(inputStream: InputStream): ByteArray {
         return inputStream.use {
-            val ivSize = it.read()
-            val iv = ByteArray(ivSize)
+            val iv = ByteArray(KEY_SIZE)
             it.read(iv)
+            val cipher = getDecryptCipherForIv(iv)
+            val outputStream = ByteArrayOutputStream()
 
-            val encryptedBytesSize = it.read()
-            val encryptedBytes = ByteArray(encryptedBytesSize)
-            it.read(encryptedBytes)
+            // read the payload in chunks to make sure to support larger data amounts (this would otherwise fail silently and result in corrupted data being read back)
+            ////////////////////////////////////
+            val buffer = ByteArray(CHUNK_SIZE)
+            while (inputStream.available() > CHUNK_SIZE) {
+                inputStream.read(buffer)
+                val ciphertextChunk = cipher.update(buffer)
+                outputStream.write(ciphertextChunk)
+            }
+            // the last chunk must be read using doFinal() because this takes the padding into account
+            val remainingBytes = inputStream.readBytes()
+            val lastChunk = cipher.doFinal(remainingBytes)
+            outputStream.write(lastChunk)
+            //////////////////////////////////
 
-            getDecryptCipherForIv(iv).doFinal(encryptedBytes)
+            outputStream.toByteArray()
         }
     }
 
     companion object {
+        private const val CHUNK_SIZE = 1024 * 4 // bytes
+        private const val KEY_SIZE = 16 // bytes
+        private const val ALIAS = "kaera"
         private const val ALGORITHM = KeyProperties.KEY_ALGORITHM_AES
         private const val BLOCK_MODE = KeyProperties.BLOCK_MODE_CBC
         private const val PADDING = KeyProperties.ENCRYPTION_PADDING_PKCS7

--- a/app/src/main/java/com/hara/kaera/data/util/CrpytoManger.kt
+++ b/app/src/main/java/com/hara/kaera/data/util/CrpytoManger.kt
@@ -1,9 +1,7 @@
-package com.hara.kaera.feature.util
+package com.hara.kaera.data.util
 
-import android.os.Build
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
-import androidx.annotation.RequiresApi
 import java.io.InputStream
 import java.io.OutputStream
 import java.security.KeyStore

--- a/app/src/main/java/com/hara/kaera/domain/dto/JWTRefreshReqDTO.kt
+++ b/app/src/main/java/com/hara/kaera/domain/dto/JWTRefreshReqDTO.kt
@@ -1,4 +1,4 @@
-package com.hara.kaera.data.dto.login
+package com.hara.kaera.domain.dto
 
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/hara/kaera/domain/dto/KaKaoLoginReqDTO.kt
+++ b/app/src/main/java/com/hara/kaera/domain/dto/KaKaoLoginReqDTO.kt
@@ -1,4 +1,4 @@
-package com.hara.kaera.data.dto.login
+package com.hara.kaera.domain.dto
 
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/hara/kaera/domain/entity/login/LoginData.kt
+++ b/app/src/main/java/com/hara/kaera/domain/entity/login/LoginData.kt
@@ -1,0 +1,9 @@
+package com.hara.kaera.domain.entity.login
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LoginData(
+    val accessToken: String? = null,
+    val refreshToken: String? = null,
+)

--- a/app/src/main/java/com/hara/kaera/domain/repository/LoginRepository.kt
+++ b/app/src/main/java/com/hara/kaera/domain/repository/LoginRepository.kt
@@ -4,6 +4,7 @@ import com.hara.kaera.core.ApiResult
 import com.hara.kaera.domain.dto.JWTRefreshReqDTO
 import com.hara.kaera.domain.dto.KaKaoLoginReqDTO
 import com.hara.kaera.domain.entity.login.KakaoLoginJWTEntity
+import com.hara.kaera.domain.entity.login.LoginData
 import kotlinx.coroutines.flow.Flow
 
 interface LoginRepository {

--- a/app/src/main/java/com/hara/kaera/domain/repository/LoginRepository.kt
+++ b/app/src/main/java/com/hara/kaera/domain/repository/LoginRepository.kt
@@ -1,8 +1,8 @@
 package com.hara.kaera.domain.repository
 
 import com.hara.kaera.core.ApiResult
-import com.hara.kaera.data.dto.login.JWTRefreshReqDTO
-import com.hara.kaera.data.dto.login.KaKaoLoginReqDTO
+import com.hara.kaera.domain.dto.JWTRefreshReqDTO
+import com.hara.kaera.domain.dto.KaKaoLoginReqDTO
 import com.hara.kaera.domain.entity.login.KakaoLoginJWTEntity
 import kotlinx.coroutines.flow.Flow
 

--- a/app/src/main/java/com/hara/kaera/feature/login/LoginActivity.kt
+++ b/app/src/main/java/com/hara/kaera/feature/login/LoginActivity.kt
@@ -121,6 +121,7 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
             is TokenState.Expired -> {
                 // 저장된 리프레시 토큰이 만료된 상태
                 // 따라서 카카오 로그인 과정을 다시 거쳐서 JWT (리프레시/액세스) 모두 갱신해야 한다
+                Timber.e("Expired")
                 kakaoLogin()
             }
         }

--- a/app/src/main/java/com/hara/kaera/feature/util/CrpytoManger.kt
+++ b/app/src/main/java/com/hara/kaera/feature/util/CrpytoManger.kt
@@ -1,0 +1,85 @@
+package com.hara.kaera.feature.util
+
+import android.os.Build
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import androidx.annotation.RequiresApi
+import java.io.InputStream
+import java.io.OutputStream
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.IvParameterSpec
+
+
+class CryptoManager {
+
+    private val keyStore = KeyStore.getInstance("AndroidKeyStore").apply {
+        load(null)
+    }
+
+    private val encryptCipher get() = Cipher.getInstance(TRANSFORMATION).apply {
+        init(Cipher.ENCRYPT_MODE, getKey())
+    }
+
+    private fun getDecryptCipherForIv(iv: ByteArray): Cipher {
+        return Cipher.getInstance(TRANSFORMATION).apply {
+            init(Cipher.DECRYPT_MODE, getKey(), IvParameterSpec(iv))
+        }
+    }
+
+    private fun getKey(): SecretKey {
+        val existingKey = keyStore.getEntry("secret", null) as? KeyStore.SecretKeyEntry
+        return existingKey?.secretKey ?: createKey()
+    }
+
+    private fun createKey(): SecretKey {
+        return KeyGenerator.getInstance(ALGORITHM).apply {
+            init(
+                KeyGenParameterSpec.Builder(
+                    "secret",
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+                )
+                    .setBlockModes(BLOCK_MODE)
+                    .setEncryptionPaddings(PADDING)
+                    .setUserAuthenticationRequired(false)
+                    .setRandomizedEncryptionRequired(true)
+                    .build()
+            )
+        }.generateKey()
+    }
+
+    fun encrypt(bytes: ByteArray, outputStream: OutputStream): ByteArray {
+        val encryptedBytes = encryptCipher.doFinal(bytes)
+        outputStream.use {
+            it.write(encryptCipher.iv.size)
+            it.write(encryptCipher.iv)
+            it.write(encryptedBytes.size)
+            it.write(encryptedBytes)
+        }
+        return encryptedBytes
+    }
+
+    fun decrypt(inputStream: InputStream): ByteArray {
+        return inputStream.use {
+            val ivSize = it.read()
+            val iv = ByteArray(ivSize)
+            it.read(iv)
+
+            val encryptedBytesSize = it.read()
+            val encryptedBytes = ByteArray(encryptedBytesSize)
+            it.read(encryptedBytes)
+
+            getDecryptCipherForIv(iv).doFinal(encryptedBytes)
+        }
+    }
+
+    companion object {
+        private const val ALGORITHM = KeyProperties.KEY_ALGORITHM_AES
+        private const val BLOCK_MODE = KeyProperties.BLOCK_MODE_CBC
+        private const val PADDING = KeyProperties.ENCRYPTION_PADDING_PKCS7
+        private const val TRANSFORMATION = "$ALGORITHM/$BLOCK_MODE/$PADDING"
+    }
+
+}


### PR DESCRIPTION
<!-- 🔥 Assignee, Label, Reviewer 설정!!!🔥 -->

## 📒 이슈

- Resolved: #71

## 🔥 작업 내용

- 데이터스토어 암호화 복호화 작업을 하였습니다. 
- PreferenceDataStore( primitive 타입만 저장가능 )에서 ProtoDataStore( Data클래스등 자체 데이터구조 저장가능 )으로 바꾸었습니다. 


## ☑️ PR Point

<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->

- 안드로이드 권장사항에 따라 자바 Cipher를 사용해 CBC모드에서 AES를 통해 암호화 하였습니다. 
- 유튜브를 많이 참고하였습니다.

## 참고자료
- https://developer.android.com/guide/topics/security/cryptography?hl=ko
- https://www.youtube.com/watch?v=D_q07P1sfcc&list=WL&index=1
- https://developers-kr.googleblog.com/2021/04/using-datastore-with-kotlin-serialization.html

## 📱실행결과

<!-- gif or mp4. gif는 [https://ezgif.com/](https://ezgif.com/) 활용! 용량제한 10MB넘어가면 카톡으로.. -->
![화면 캡처 2023-09-27 213610](https://github.com/TeamHARA/KAERA_Android/assets/70648111/8fafbb16-6b2e-487e-8d7a-a44feeb5b38a)
