### PR TITLE
Feat/#78 '고민 이후 기록' 수정 취소 시 다이얼로그 추가

### DIFF
--- a/app/src/main/java/com/hara/kaera/feature/detail/DetailAfterViewModel.kt
+++ b/app/src/main/java/com/hara/kaera/feature/detail/DetailAfterViewModel.kt
@@ -1,5 +1,6 @@
 package com.hara.kaera.feature.detail
 
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hara.kaera.core.ApiResult
@@ -31,6 +32,9 @@ class DetailAfterViewModel @Inject constructor(
     val deleteWorryFlow = _deleteWorryFlow.asStateFlow()
     private val _reviewWorryFlow = MutableStateFlow<UiState<ReviewResEntity>>(UiState.Init)
     val reviewWorryFlow = _reviewWorryFlow.asStateFlow()
+
+    private val _reviewContent = MutableLiveData<String>()
+    var reviewContent = _reviewContent.value
 
     fun getWorryDetail(worryId: Int) {
         this.worryId = worryId

--- a/app/src/main/java/com/hara/kaera/feature/detail/custom/DialogUpdateWarning.kt
+++ b/app/src/main/java/com/hara/kaera/feature/detail/custom/DialogUpdateWarning.kt
@@ -1,0 +1,29 @@
+package com.hara.kaera.feature.detail.custom
+
+import android.os.Bundle
+import android.view.View
+import com.hara.kaera.R
+import com.hara.kaera.databinding.DialogWarningBinding
+import com.hara.kaera.feature.base.BindingDialogFragment
+import com.hara.kaera.feature.util.onSingleClick
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class DialogUpdateWarning(
+    private val yesClickListener: () -> Unit,
+) : BindingDialogFragment<DialogWarningBinding>(R.layout.dialog_warning, 16) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setListeners()
+    }
+
+    private fun setListeners() {
+        binding.btnYes.setOnClickListener {
+            this.dismiss()
+            yesClickListener.invoke()
+        }
+        binding.btnNo.onSingleClick() {
+            dismiss()
+        }
+    }
+}


### PR DESCRIPTION
<!-- 🔥 Assignee, Label, Reviewer 설정!!!🔥 -->

## 📒 이슈

- Resolved: #78

## 🔥 작업 내용

- 고민 상세 조회 뷰(고민 완료) - 기록 수정 유무에 따른 경고 다이얼로그 추가했습니다.
- 서버 통신이 이어지는 setOnClickListener -> SingleClickListenr로 변경했습니다.
- 몇몇 함수명 통일성 있게 수정했습니다.

## ☑️ PR Point

<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->

- 빈 스트링 입력 후 API 호출할 경우 400 에러("body 에 review 값이 존재하지 않습니다")가 나서 해당 부분 기획 로직 확인 받고 서버님께 전달드렸습니다!

## 📱실행결과

<!-- gif or mp4. gif는 [https://ezgif.com/](https://ezgif.com/) 활용! 용량제한 10MB넘어가면 카톡으로.. -->

https://github.com/TeamHARA/KAERA_Android/assets/69359774/b94483ae-50df-42e7-8e6d-54f2dc312284



