### PR TITLE
Fix/#93 고민 목록 조회 API 수정된 부분 반영

### DIFF
--- a/app/src/main/java/com/hara/kaera/data/datasource/remote/KaeraApi.kt
+++ b/app/src/main/java/com/hara/kaera/data/datasource/remote/KaeraApi.kt
@@ -41,9 +41,11 @@ interface KaeraApi {
         @Path("templateId") templateId: Int,
     ): TemplateDetailDTO
 
-    @GET("worry/list/{isSolved}")
+    @GET("worry/{isSolved}/list")
     suspend fun getHomeWorryList(
         @Path("isSolved") isSolved: Int,
+        @Query("page") page: Int,
+        @Query("limit") limit: Int,
     ): HomeWorryListDTO
 
     @GET("worry/")

--- a/app/src/main/java/com/hara/kaera/data/datasource/remote/KaeraDataSource.kt
+++ b/app/src/main/java/com/hara/kaera/data/datasource/remote/KaeraDataSource.kt
@@ -33,7 +33,7 @@ interface KaeraDataSource {
 
     fun getTemplateDetail(templateId: Int): Flow<TemplateDetailDTO>
 
-    fun getHomeWorryList(isSolved: Int): Flow<HomeWorryListDTO>
+    fun getHomeWorryList(isSolved: Int, page: Int, limit: Int): Flow<HomeWorryListDTO>
 
     fun getWorryByTemplate(templateId: Int): Flow<WorryByTemplateDTO>
 

--- a/app/src/main/java/com/hara/kaera/data/datasource/remote/KaeraDataSourceImpl.kt
+++ b/app/src/main/java/com/hara/kaera/data/datasource/remote/KaeraDataSourceImpl.kt
@@ -44,9 +44,9 @@ class KaeraDataSourceImpl @Inject constructor(
         }.safeCallApi()
     }
 
-    override fun getHomeWorryList(isSolved: Int): Flow<HomeWorryListDTO> {
+    override fun getHomeWorryList(isSolved: Int, page: Int, limit: Int): Flow<HomeWorryListDTO> {
         return flow {
-            emit(kaeraApi.getHomeWorryList(isSolved))
+            emit(kaeraApi.getHomeWorryList(isSolved, page, limit))
         }.safeCallApi()
     }
 

--- a/app/src/main/java/com/hara/kaera/data/repository/KaeraRepositoryImpl.kt
+++ b/app/src/main/java/com/hara/kaera/data/repository/KaeraRepositoryImpl.kt
@@ -65,9 +65,9 @@ class KaeraRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun getHomeWorryList(isSolved: Int): Flow<ApiResult<HomeWorryListEntity>> {
+    override fun getHomeWorryList(isSolved: Int, page: Int, limit: Int): Flow<ApiResult<HomeWorryListEntity>> {
         return flow {
-            kaeraDataSource.getHomeWorryList(isSolved).catch {
+            kaeraDataSource.getHomeWorryList(isSolved, page, limit).catch {
                 emit(ApiResult.Error(errorHandler(it)))
             }.collect {
                 emit(ApiResult.Success(mapperToHomeWorryList(it)))

--- a/app/src/main/java/com/hara/kaera/domain/repository/KaeraRepository.kt
+++ b/app/src/main/java/com/hara/kaera/domain/repository/KaeraRepository.kt
@@ -23,7 +23,7 @@ interface KaeraRepository {
 
     fun getTemplateDetailInfo(templateId: Int): Flow<ApiResult<TemplateDetailEntity>>
 
-    fun getHomeWorryList(isSolved: Int): Flow<ApiResult<HomeWorryListEntity>>
+    fun getHomeWorryList(isSolved: Int, page: Int, limit: Int): Flow<ApiResult<HomeWorryListEntity>>
 
     fun getWorryByTemplate(templateId: Int): Flow<ApiResult<WorryByTemplateEntity>>
 

--- a/app/src/main/java/com/hara/kaera/domain/usecase/GetHomeWorryListUseCase.kt
+++ b/app/src/main/java/com/hara/kaera/domain/usecase/GetHomeWorryListUseCase.kt
@@ -5,5 +5,5 @@ import com.hara.kaera.domain.entity.HomeWorryListEntity
 import kotlinx.coroutines.flow.Flow
 
 interface GetHomeWorryListUseCase {
-    operator fun invoke(isSolved: Int): Flow<ApiResult<HomeWorryListEntity>>
+    operator fun invoke(isSolved: Int, page: Int, limit: Int): Flow<ApiResult<HomeWorryListEntity>>
 }

--- a/app/src/main/java/com/hara/kaera/domain/usecase/GetHomeWorryListUseCaseImpl.kt
+++ b/app/src/main/java/com/hara/kaera/domain/usecase/GetHomeWorryListUseCaseImpl.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class GetHomeWorryListUseCaseImpl @Inject constructor(private val repository: KaeraRepository): GetHomeWorryListUseCase {
-    override fun invoke(isSolved: Int): Flow<ApiResult<HomeWorryListEntity>> {
-        return repository.getHomeWorryList(isSolved)
+    override fun invoke(isSolved: Int, page: Int, limit: Int): Flow<ApiResult<HomeWorryListEntity>> {
+        return repository.getHomeWorryList(isSolved, page, limit)
     }
 }

--- a/app/src/main/java/com/hara/kaera/feature/home/HomeViewModel.kt
+++ b/app/src/main/java/com/hara/kaera/feature/home/HomeViewModel.kt
@@ -46,7 +46,7 @@ class HomeViewModel @Inject constructor(
         flow.value = UiState.Loading
         viewModelScope.launch {
             kotlin.runCatching {
-                homeUseCase(if (!isSolved) 0 else 1)
+                homeUseCase(if (!isSolved) 0 else 1, 1, 12)
             }.onSuccess {
                 it.collect { collect ->
                     Timber.e("[ABC] HomeViewModel/getHomeWorryList - 통신1")

--- a/app/src/main/java/com/hara/kaera/feature/home/HomeViewModel.kt
+++ b/app/src/main/java/com/hara/kaera/feature/home/HomeViewModel.kt
@@ -46,7 +46,7 @@ class HomeViewModel @Inject constructor(
         flow.value = UiState.Loading
         viewModelScope.launch {
             kotlin.runCatching {
-                homeUseCase(if (!isSolved) 0 else 1, 1, 12)
+                homeUseCase(if (!isSolved) 0 else 1, firstPage, itemLimit)
             }.onSuccess {
                 it.collect { collect ->
                     Timber.e("[ABC] HomeViewModel/getHomeWorryList - 통신1")
@@ -77,6 +77,11 @@ class HomeViewModel @Inject constructor(
                 UiState.Error("[홈 화면/원석 display] 서버가 불안정합니다.")
             }
         }
+    }
+
+    companion object {
+        const val firstPage = 1
+        const val itemLimit = 12
     }
 
 //    init {


### PR DESCRIPTION
<!-- 🔥 Assignee, Label, Reviewer 설정!!!🔥 -->

## 📒 이슈

- Resolved: #93

## 🔥 작업 내용

- 고민 목록 조회 API 수정된 부분 반영했습니다

## ☑️ PR Point

<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->

- 홈 화면 건드린 김에 12개 초과 시 작성 불가 다이얼로그까지 작업 하려고 했는데 수정될 코드가 많을 것 같아 보류합니다..
(MainActiviy, HomeFragment가 HomeViewModel을 공유하고, isSolved=0으로 서버통신 했을 때 원석 크기를 LiveData로 저장하려고 했는데 이러면 서버 통신 코드(수현 언니가 한 부분)를 다시 2개로 분리해야 할 것 같아요)

- 커밋을 너무 쪼갠 것 같아요,, 나머지 자잘한 부분은 한꺼번에 올리겠습니다

## 📱실행결과

<!-- gif or mp4. gif는 [https://ezgif.com/](https://ezgif.com/) 활용! 용량제한 10MB넘어가면 카톡으로.. -->
