### PR TITLE
Feat/#97 토큰 재설정 관련 인터셉터 추가

### DIFF
--- a/app/src/main/java/com/hara/kaera/data/util/BaseInterceptor.kt
+++ b/app/src/main/java/com/hara/kaera/data/util/BaseInterceptor.kt
@@ -1,6 +1,5 @@
 package com.hara.kaera.data.util
 
-import com.hara.kaera.BuildConfig
 import com.hara.kaera.application.Constant
 import com.hara.kaera.data.datasource.remote.LoginDataSource
 import com.hara.kaera.domain.dto.JWTRefreshReqDTO
@@ -12,11 +11,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Response
-import javax.inject.Inject
-import javax.inject.Singleton
 
 
-class BaseInterceptor (
+class BaseInterceptor(
     private val loginRepository: LoginRepository,
     private val loginDataStore: LoginDataSource
 ) : Interceptor {

--- a/app/src/main/java/com/hara/kaera/data/util/BaseInterceptor.kt
+++ b/app/src/main/java/com/hara/kaera/data/util/BaseInterceptor.kt
@@ -1,0 +1,74 @@
+package com.hara.kaera.data.util
+
+import com.hara.kaera.BuildConfig
+import com.hara.kaera.application.Constant
+import com.hara.kaera.data.datasource.remote.LoginDataSource
+import com.hara.kaera.domain.dto.JWTRefreshReqDTO
+import com.hara.kaera.domain.repository.LoginRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+import javax.inject.Singleton
+
+
+class BaseInterceptor (
+    private val loginRepository: LoginRepository,
+    private val loginDataStore: LoginDataSource
+) : Interceptor {
+
+    val authToken: String = runBlocking {
+        loginRepository.getSavedAccessToken().first()
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+
+        val request = chain.request().newBuilder()
+            .addHeader("Accept", Constant.APPLICATION_JSON)
+            .addHeader("Authorization", authToken ?: "nothing")
+            //.addHeader("Authorization", BuildConfig.BEARER_TOKEN)
+            .build()
+
+        var response = chain.proceed(request)
+
+        if (response.code == 401) {
+            val refreshToken: String = runBlocking {
+                loginRepository.getSavedRefreshToken().first()
+            }
+            CoroutineScope(Dispatchers.IO).launch {
+                kotlin.runCatching {
+                    loginDataStore.getAccessToken(
+                        JWTRefreshReqDTO(
+                            accessToken = authToken,
+                            refreshToken = refreshToken
+                        )
+                    )
+                }
+                    .onSuccess {
+                        it.collect {
+                            loginRepository.updateAccessToken(accessToken = it.data.accessToken)
+                        }
+                    }.onFailure {
+                        throw it
+                    }
+            }
+
+            val newAuthToken: String = runBlocking {
+                loginRepository.getSavedAccessToken().first()
+            }
+
+            val newRequest = chain.request().newBuilder()
+                .addHeader("Accept", Constant.APPLICATION_JSON)
+                .addHeader("Authorization", newAuthToken ?: "nothing")
+                .build()
+            response = chain.proceed(newRequest)
+        }
+
+        return response
+
+    }
+}

--- a/app/src/main/java/com/hara/kaera/data/util/SafeFlow.kt
+++ b/app/src/main/java/com/hara/kaera/data/util/SafeFlow.kt
@@ -6,13 +6,30 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.retry
+import retrofit2.HttpException
 
 fun <T> Flow<T>.safeCallApi(): Flow<T> {
     return this.flowOn(Dispatchers.IO).catch {
         throw it
     }.retry(3) {
-        delay(1000)
-        true
+        if (it is HttpException) {
+            when (it.code()) {
+                401 -> {
+                    false
+                }
+
+                else -> {
+                    delay(1000)
+                    true
+                }
+            }
+        } else {
+            delay(1000)
+            true
+        }
+
     } // exception 발생시 1초 간격으로 최대 3번 재시도 이후 
     // 버튼을 통해 새로고침 하는 방식이면 사라질 코드
+    // 401인 경우에는 interceptor를 통해서 토큰 재발급 로직을 수행하므로
+    // 재시도하지 않도록 처리
 }

--- a/app/src/main/java/com/hara/kaera/di/ServiceModule.kt
+++ b/app/src/main/java/com/hara/kaera/di/ServiceModule.kt
@@ -5,8 +5,8 @@ import com.hara.kaera.application.Constant
 import com.hara.kaera.data.datasource.remote.KaeraApi
 import com.hara.kaera.data.datasource.remote.LoginApi
 import com.hara.kaera.data.datasource.remote.LoginDataSource
+import com.hara.kaera.data.util.BaseInterceptor
 import com.hara.kaera.data.util.ErrorHandlerImpl
-import com.hara.kaera.domain.dto.JWTRefreshReqDTO
 import com.hara.kaera.domain.repository.LoginRepository
 import com.hara.kaera.domain.util.ErrorHandler
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
@@ -14,11 +14,6 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import okhttp3.Interceptor
@@ -43,56 +38,8 @@ object ServiceModule {
     @KAREARetrofit
     fun providesKaeraHeaderInterceptor(
         loginRepository: LoginRepository,
-        loginDataStore: LoginDataSource
-    ): Interceptor {
-
-        val authToken: String = runBlocking {
-            loginRepository.getSavedAccessToken().first()
-        }
-
-        return Interceptor { chain ->
-            var request = chain.request().newBuilder()
-                .addHeader("Accept", Constant.APPLICATION_JSON)
-                //.addHeader("Authorization", authToken ?: "nothing")
-                .addHeader("Authorization", BuildConfig.BEARER_TOKEN)
-                .build()
-
-            if (chain.proceed(request).code == 401) {
-                val refreshToken: String = runBlocking {
-                    loginRepository.getSavedRefreshToken().first()
-                }
-                CoroutineScope(Dispatchers.IO).launch {
-                    kotlin.runCatching {
-                        loginDataStore.getAccessToken(
-                            JWTRefreshReqDTO(
-                                accessToken = authToken,
-                                refreshToken = refreshToken
-                            )
-                        )
-                    }
-                        .onSuccess {
-                            it.collect {
-                                loginRepository.updateAccessToken(accessToken = it.data.accessToken)
-                            }
-                        }.onFailure {
-                            throw it
-                        }
-                }
-
-                val newAuthToken: String = runBlocking {
-                    loginRepository.getSavedAccessToken().first()
-                }
-
-                val newRequest = chain.request().newBuilder()
-                    .addHeader("Accept", Constant.APPLICATION_JSON)
-                    .addHeader("Authorization", newAuthToken ?: "nothing")
-                    .build()
-                chain.proceed(newRequest)
-            }else{
-                chain.proceed(request)
-            }
-        }
-    }
+        loginDataSource: LoginDataSource
+    ): Interceptor = BaseInterceptor(loginRepository, loginDataSource)
 
 
     @Provides

--- a/app/src/main/java/com/hara/kaera/di/ServiceModule.kt
+++ b/app/src/main/java/com/hara/kaera/di/ServiceModule.kt
@@ -4,7 +4,9 @@ import com.hara.kaera.BuildConfig
 import com.hara.kaera.application.Constant
 import com.hara.kaera.data.datasource.remote.KaeraApi
 import com.hara.kaera.data.datasource.remote.LoginApi
+import com.hara.kaera.data.datasource.remote.LoginDataSource
 import com.hara.kaera.data.util.ErrorHandlerImpl
+import com.hara.kaera.domain.dto.JWTRefreshReqDTO
 import com.hara.kaera.domain.repository.LoginRepository
 import com.hara.kaera.domain.util.ErrorHandler
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
@@ -12,7 +14,10 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
@@ -21,7 +26,6 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
-import timber.log.Timber
 import javax.inject.Qualifier
 import javax.inject.Singleton
 
@@ -38,19 +42,54 @@ object ServiceModule {
     @Singleton
     @KAREARetrofit
     fun providesKaeraHeaderInterceptor(
-        loginRepositroy: LoginRepository
+        loginRepository: LoginRepository,
+        loginDataStore: LoginDataSource
     ): Interceptor {
+
         val authToken: String = runBlocking {
-            loginRepositroy.getSavedAccessToken().first()
+            loginRepository.getSavedAccessToken().first()
         }
+
         return Interceptor { chain ->
-            with(chain) {
-                val request = request().newBuilder()
+            var request = chain.request().newBuilder()
+                .addHeader("Accept", Constant.APPLICATION_JSON)
+                //.addHeader("Authorization", authToken ?: "nothing")
+                .addHeader("Authorization", BuildConfig.BEARER_TOKEN)
+                .build()
+
+            if (chain.proceed(request).code == 401) {
+                val refreshToken: String = runBlocking {
+                    loginRepository.getSavedRefreshToken().first()
+                }
+                CoroutineScope(Dispatchers.IO).launch {
+                    kotlin.runCatching {
+                        loginDataStore.getAccessToken(
+                            JWTRefreshReqDTO(
+                                accessToken = authToken,
+                                refreshToken = refreshToken
+                            )
+                        )
+                    }
+                        .onSuccess {
+                            it.collect {
+                                loginRepository.updateAccessToken(accessToken = it.data.accessToken)
+                            }
+                        }.onFailure {
+                            throw it
+                        }
+                }
+
+                val newAuthToken: String = runBlocking {
+                    loginRepository.getSavedAccessToken().first()
+                }
+
+                val newRequest = chain.request().newBuilder()
                     .addHeader("Accept", Constant.APPLICATION_JSON)
-                    .addHeader("Authorization", authToken)
-                    //.addHeader("Authorization", BuildConfig.BEARER_TOKEN)
+                    .addHeader("Authorization", newAuthToken ?: "nothing")
                     .build()
-                proceed(request)
+                chain.proceed(newRequest)
+            }else{
+                chain.proceed(request)
             }
         }
     }


### PR DESCRIPTION
<!-- 🔥 Assignee, Label, Reviewer 설정!!!🔥 -->

## 📒 이슈

- Resolved: #97

## 문제상황 

- 앱 사용중 액세스토큰이 만료되었을때(2시간) 401이 발생하여서 최악의 경우 고민작성 api가 정상적으로 수행하지 않게되어서 사용자에게 불편을 줄 수도 있다.

## 🔥 작업 내용

- 레트로핏 객체 중에서 헤더를 달아주기 위한 Header Interceptor 부분에 401(유효하지 않은 사용자)인 경우 액세스 토큰을 재설정 해주는 로직을 넣어줬습니다. 

## ☑️ PR Point

<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->

- 아직 완벽하지는 않아서 만약 앱 사용중 액세스토큰이 만료되어버리게 되면 지속적으로 토큰 재설정 api를 부르게 됩니다. 
하지만 최악의 케이스( 토큰이 만료되어서 앱 사용이 매끄럽지 않게되는 경우 )는 방지하게 됩니다.

## 📱실행결과
![화면 캡처 2023-11-24 230738](https://github.com/TeamHARA/KAERA_Android/assets/70648111/07ff8c70-9646-4abd-84d6-bf3b4bbad6ba)

<!-- gif or mp4. gif는 [https://ezgif.com/](https://ezgif.com/) 활용! 용량제한 10MB넘어가면 카톡으로.. -->
