### PR TITLE
Feat/#107 홈 리싸이클러뷰 관련 처리 / 마이페이지 스크롤화 / 화면전환 애니메이션 적용

### DIFF
--- a/app/src/main/java/com/hara/kaera/feature/base/BindingActivity.kt
+++ b/app/src/main/java/com/hara/kaera/feature/base/BindingActivity.kt
@@ -5,6 +5,7 @@ import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
+import com.hara.kaera.R
 
 abstract class BindingActivity<T : ViewDataBinding>(
     @LayoutRes private val layoutResId: Int
@@ -15,7 +16,13 @@ abstract class BindingActivity<T : ViewDataBinding>(
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        overridePendingTransition(R.anim.animation_slide_from_left, R.anim.anim_none)
         _binding = DataBindingUtil.setContentView(this, layoutResId)
         binding.lifecycleOwner = this
+    }
+
+    override fun finish() {
+        super.finish()
+        overridePendingTransition(R.anim.anim_none, R.anim.animation_slide_to_left)
     }
 }

--- a/app/src/main/java/com/hara/kaera/feature/home/HomeFragment.kt
+++ b/app/src/main/java/com/hara/kaera/feature/home/HomeFragment.kt
@@ -16,8 +16,6 @@ import timber.log.Timber
 @AndroidEntryPoint
 class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home) {
 
-    private val viewModel by viewModels<HomeViewModel>()
-
     private lateinit var adapter: HomeFragmentStateAdapter
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/hara/kaera/feature/home/adapter/HomeJewelAdapter.kt
+++ b/app/src/main/java/com/hara/kaera/feature/home/adapter/HomeJewelAdapter.kt
@@ -7,6 +7,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.hara.kaera.databinding.ItemHomeGemBinding
 import com.hara.kaera.domain.entity.HomeWorryListEntity
 import com.hara.kaera.feature.home.FloatingAnimation
+import com.hara.kaera.feature.util.Constant
 import com.hara.kaera.feature.util.GlobalDiffCallBack
 
 class HomeJewelAdapter(
@@ -43,8 +44,10 @@ class HomeJewelAdapter(
             ).start()
 
             // 고민 후 상세보기로 이동
-            root.setOnClickListener { jewel ->
-                goToDetailAfterActivity(curItem.worryId)
+            if (curItem.worryId != Constant.dummyGemStoneId) {
+                root.setOnClickListener { jewel ->
+                    goToDetailAfterActivity(curItem.worryId)
+                }
             }
         }
     }

--- a/app/src/main/java/com/hara/kaera/feature/home/adapter/HomeStoneAdapter.kt
+++ b/app/src/main/java/com/hara/kaera/feature/home/adapter/HomeStoneAdapter.kt
@@ -1,15 +1,13 @@
 package com.hara.kaera.feature.home.adapter
 
-import android.content.Intent
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.core.content.ContextCompat.startActivity
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.hara.kaera.databinding.ItemHomeGemBinding
 import com.hara.kaera.domain.entity.HomeWorryListEntity
-import com.hara.kaera.feature.detail.DetailAfterActivity
 import com.hara.kaera.feature.home.FloatingAnimation
+import com.hara.kaera.feature.util.Constant
 import com.hara.kaera.feature.util.GlobalDiffCallBack
 import timber.log.Timber
 
@@ -48,9 +46,10 @@ class HomeStoneAdapter(
             ).start()
 
             // 고민 전 상세보기로 이동
-            root.setOnClickListener { stone ->
-                goToDetailBeforeActivity(curItem.worryId)
-            }
+            if (curItem.worryId != Constant.dummyGemStoneId)
+                root.setOnClickListener { stone ->
+                    goToDetailBeforeActivity(curItem.worryId)
+                }
         }
     }
 }

--- a/app/src/main/java/com/hara/kaera/feature/home/gems/HomeFragmentStateAdapter.kt
+++ b/app/src/main/java/com/hara/kaera/feature/home/gems/HomeFragmentStateAdapter.kt
@@ -34,11 +34,4 @@ class HomeFragmentStateAdapter(
         }
     }
 
-//    override fun getItemId(position: Int): Long {
-//        return fragmentList[position].id.toLong()
-//    }
-//
-//    override fun containsItem(itemId: Long): Boolean {
-//        return fragmentList.any { it.id.toLong() == itemId }
-//    }
 }

--- a/app/src/main/java/com/hara/kaera/feature/util/Constant.kt
+++ b/app/src/main/java/com/hara/kaera/feature/util/Constant.kt
@@ -8,4 +8,5 @@ object Constant {
     const val thanksToId = 5
     const val completeSnackBarLocationY = -160.0
     const val infiniteDeadLine = 888
+    const val dummyGemStoneId = -1
 }

--- a/app/src/main/res/anim/anim_none.xml
+++ b/app/src/main/res/anim/anim_none.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:fromXDelta="0%"
+        android:fromYDelta="0%"
+        android:toXDelta="0%"
+        android:toYDelta="0%" />
+</set>

--- a/app/src/main/res/anim/animation_slide_from_left.xml
+++ b/app/src/main/res/anim/animation_slide_from_left.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="300"
+        android:fromXDelta="-100%"
+        android:interpolator="@android:anim/accelerate_interpolator"
+        android:toXDelta="0%" />
+</set>

--- a/app/src/main/res/anim/animation_slide_to_left.xml
+++ b/app/src/main/res/anim/animation_slide_to_left.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="300"
+        android:fromXDelta="0%"
+        android:interpolator="@android:anim/accelerate_interpolator"
+        android:toXDelta="-100%" />
+</set>

--- a/app/src/main/res/layout/activity_mypage.xml
+++ b/app/src/main/res/layout/activity_mypage.xml
@@ -37,214 +37,230 @@
                 app:titleTextColor="@color/white" />
         </com.google.android.material.appbar.AppBarLayout>
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/cl_user_info"
+        <ScrollView
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="16dp"
-            android:layout_marginTop="36dp"
-            android:background="@drawable/shape_rect_gray2_8"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/appBarLayout">
+            app:layout_constraintTop_toBottomOf="@+id/appBarLayout">
 
-            <TextView
-                android:id="@+id/tv_user_name"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginVertical="24dp"
-                android:layout_marginStart="15dp"
-                android:text="@{vm.savedName}"
-                android:textAppearance="@style/h_head1_b20"
-                android:textColor="@color/white"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="이름" />
-
-            <!--     TODO: 이미지 변경       -->
-            <ImageView
-                android:id="@+id/iv_view_kakao_login"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="12dp"
-                android:src="@drawable/icn_white_kakao"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <TextView
-            android:id="@+id/tv_alert_setting"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginVertical="24dp"
-            android:layout_marginStart="15dp"
-            android:layout_marginTop="55dp"
-            android:text="@string/mypage_title"
-            android:textAppearance="@style/h_head2_b18"
-            android:textColor="@color/white"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/cl_user_info" />
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/cl_push_alert"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingVertical="20dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tv_alert_setting">
-
-            <TextView
-                android:id="@+id/tv_alert"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="15dp"
-                android:text="@string/mypage_push_alert"
-                android:textAppearance="@style/h_body2_r16"
-                android:textColor="@color/white"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/tb_alert_toggle"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_mypage"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="21dp"
-                android:switchMinWidth="0dp"
-                android:textOff=""
-                android:textOn=""
-                android:thumb="@drawable/switch_thumb"
-                android:thumbTextPadding="24dp"
-                app:layout_constraintBottom_toBottomOf="@id/tv_alert"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/tv_alert"
-                app:thumbTint="@drawable/thumb_tint"
-                app:track="@drawable/switch_track"
-                app:trackTint="@drawable/track_tint" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                android:layout_height="wrap_content">
 
-        <View
-            android:id="@+id/alert_divider"
-            android:layout_width="match_parent"
-            android:layout_height="13dp"
-            android:layout_marginTop="32dp"
-            android:background="@color/gray_2"
-            app:layout_constraintTop_toBottomOf="@+id/cl_push_alert" />
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/cl_user_info"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="16dp"
+                    android:layout_marginTop="36dp"
+                    android:background="@drawable/shape_rect_gray2_8"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent">
 
-        <TextView
-            android:id="@+id/tv_tos"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginVertical="24dp"
-            android:layout_marginStart="15dp"
-            android:layout_marginTop="42dp"
-            android:text="@string/mypage_tos"
-            android:textAppearance="@style/h_head2_b18"
-            android:textColor="@color/white"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/alert_divider" />
+                    <TextView
+                        android:id="@+id/tv_user_name"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginVertical="24dp"
+                        android:layout_marginStart="15dp"
+                        android:text="@{vm.savedName}"
+                        android:textAppearance="@style/h_head1_b20"
+                        android:textColor="@color/white"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:text="이름" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/cl_service"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            android:paddingVertical="24dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tv_tos">
+                    <ImageView
+                        android:id="@+id/iv_view_kakao_login"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="12dp"
+                        android:src="@drawable/icn_white_kakao"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <TextView
-                android:id="@+id/tv_service"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="15dp"
-                android:text="@string/mypage_tos_service"
-                android:textAppearance="@style/h_body2_r16"
-                android:textColor="@color/white"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                <TextView
+                    android:id="@+id/tv_alert_setting"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginVertical="24dp"
+                    android:layout_marginStart="15dp"
+                    android:layout_marginTop="55dp"
+                    android:text="@string/mypage_title"
+                    android:textAppearance="@style/h_head2_b18"
+                    android:textColor="@color/white"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/cl_user_info" />
 
-            <ImageView
-                android:id="@+id/iv_service_next"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="16dp"
-                android:src="@drawable/icn_next"
-                app:layout_constraintBottom_toBottomOf="@id/tv_service"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/tv_service" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/cl_push_alert"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingVertical="20dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/tv_alert_setting">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/cl_privacy"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingVertical="24dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/cl_service">
+                    <TextView
+                        android:id="@+id/tv_alert"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="15dp"
+                        android:text="@string/mypage_push_alert"
+                        android:textAppearance="@style/h_body2_r16"
+                        android:textColor="@color/white"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
 
-            <TextView
-                android:id="@+id/tv_privacy"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="15dp"
-                android:text="@string/mypage_tos_privacy"
-                android:textAppearance="@style/h_body2_r16"
-                android:textColor="@color/white"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                    <androidx.appcompat.widget.SwitchCompat
+                        android:id="@+id/tb_alert_toggle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="21dp"
+                        android:switchMinWidth="0dp"
+                        android:textOff=""
+                        android:textOn=""
+                        android:thumb="@drawable/switch_thumb"
+                        android:thumbTextPadding="24dp"
+                        app:layout_constraintBottom_toBottomOf="@id/tv_alert"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="@+id/tv_alert"
+                        app:thumbTint="@drawable/thumb_tint"
+                        app:track="@drawable/switch_track"
+                        app:trackTint="@drawable/track_tint" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <ImageView
-                android:id="@+id/iv_privacy_next"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="16dp"
-                android:src="@drawable/icn_next"
-                app:layout_constraintBottom_toBottomOf="@id/tv_privacy"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/tv_privacy" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                <View
+                    android:id="@+id/alert_divider"
+                    android:layout_width="match_parent"
+                    android:layout_height="13dp"
+                    android:layout_marginTop="32dp"
+                    android:background="@color/gray_2"
+                    app:layout_constraintTop_toBottomOf="@+id/cl_push_alert" />
 
-        <View
-            android:id="@+id/tos_divider"
-            android:layout_width="match_parent"
-            android:layout_height="13dp"
-            android:layout_marginTop="32dp"
-            android:background="@color/gray_2"
-            app:layout_constraintTop_toBottomOf="@+id/cl_privacy" />
+                <TextView
+                    android:id="@+id/tv_tos"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginVertical="24dp"
+                    android:layout_marginStart="15dp"
+                    android:layout_marginTop="42dp"
+                    android:text="@string/mypage_tos"
+                    android:textAppearance="@style/h_head2_b18"
+                    android:textColor="@color/white"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/alert_divider" />
 
-        <TextView
-            android:id="@+id/btn_logout"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="50dp"
-            android:layout_marginVertical="24dp"
-            android:layout_marginTop="44dp"
-            android:background="@drawable/shape_rect_gray2_8"
-            android:paddingVertical="17dp"
-            android:text="@string/logout"
-            android:textAlignment="center"
-            android:textAppearance="@style/h_body1_b16"
-            android:textColor="@color/white"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tos_divider" />
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/cl_service"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:paddingVertical="24dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/tv_tos">
 
-        <TextView
-            android:id="@+id/tv_signout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="15dp"
-            android:text="@{Html.fromHtml(@string/sign_out)}"
-            android:textAppearance="@style/h_body2_r16"
-            android:textColor="@color/gray_4"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/btn_logout"
-            tools:text="@string/sign_out" />
+                    <TextView
+                        android:id="@+id/tv_service"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="15dp"
+                        android:text="@string/mypage_tos_service"
+                        android:textAppearance="@style/h_body2_r16"
+                        android:textColor="@color/white"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
 
+                    <ImageView
+                        android:id="@+id/iv_service_next"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="16dp"
+                        android:src="@drawable/icn_next"
+                        app:layout_constraintBottom_toBottomOf="@id/tv_service"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="@+id/tv_service" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/cl_privacy"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingVertical="24dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/cl_service">
+
+                    <TextView
+                        android:id="@+id/tv_privacy"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="15dp"
+                        android:text="@string/mypage_tos_privacy"
+                        android:textAppearance="@style/h_body2_r16"
+                        android:textColor="@color/white"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <ImageView
+                        android:id="@+id/iv_privacy_next"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="16dp"
+                        android:src="@drawable/icn_next"
+                        app:layout_constraintBottom_toBottomOf="@id/tv_privacy"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="@+id/tv_privacy" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <View
+                    android:id="@+id/tos_divider"
+                    android:layout_width="match_parent"
+                    android:layout_height="13dp"
+                    android:layout_marginTop="32dp"
+                    android:background="@color/gray_2"
+                    app:layout_constraintTop_toBottomOf="@+id/cl_privacy" />
+
+                <TextView
+                    android:id="@+id/btn_logout"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="50dp"
+                    android:layout_marginVertical="24dp"
+                    android:layout_marginTop="44dp"
+                    android:background="@drawable/shape_rect_gray2_8"
+                    android:paddingVertical="17dp"
+                    android:text="@string/logout"
+                    android:textAlignment="center"
+                    android:textAppearance="@style/h_body1_b16"
+                    android:textColor="@color/white"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/tos_divider" />
+
+                <TextView
+                    android:id="@+id/tv_signout"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="15dp"
+                    android:layout_marginBottom="50dp"
+                    android:text="@{Html.fromHtml(@string/sign_out)}"
+                    android:textAppearance="@style/h_body2_r16"
+                    android:textColor="@color/gray_4"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/btn_logout"
+                    tools:text="@string/sign_out" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </ScrollView>
     </androidx.constraintlayout.widget.ConstraintLayout>
+
 </layout>


### PR DESCRIPTION
<!-- 🔥 Assignee, Label, Reviewer 설정!!!🔥 -->

## 📒 이슈

- Resolved: #107

## 🔥 작업 내용

- 리싸이클러뷰에서 보석/원석이 없는 위치를 터치했을때 상세화면으로 넘어가는 오류 수정
- 마이페이지가 기기높이가 낮은 경우 아래화면이 짤려서 스크롤뷰 적용
- 화면전환 애니메이션 적용 

## ☑️ PR Point

<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->

- 일부기기에서 애니메이션이 온전히 적용이 안되고 있어서.. 각자 기기에서 테스트해주고 알려주세요


에뮬레이터에서는 됨
[Screen_recording_20231213_152019.webm](https://github.com/TeamHARA/KAERA_Android/assets/70648111/9af20d18-4267-420c-a3c4-a18ae4545ccc)

## 📱실행결과

### 마이페이지 화면 짤리는 경우 
![Screenshot_20231213_115652](https://github.com/TeamHARA/KAERA_Android/assets/70648111/fa7db601-ec12-4e39-b6a3-fe6431206ce2)

<!-- gif or mp4. gif는 [https://ezgif.com/](https://ezgif.com/) 활용! 용량제한 10MB넘어가면 카톡으로.. -->
