### PR TITLE
Feat/#118 알림권한 플로우 수정 / manifest exported 속성 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
 
         <activity
             android:name=".feature.login.LoginActivity"
-            android:exported="true" />
+            android:exported="false" />
         <activity
             android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
             android:exported="true">
@@ -65,33 +65,29 @@
 
         <activity
             android:name=".feature.MainActivity"
-            android:exported="true">
-
-        </activity>
-
+            android:exported="false" />
         <activity
             android:name=".feature.onboarding.OnboardingActivity"
-            android:exported="true" />
-
+            android:exported="false" />
         <activity
             android:name=".feature.detail.DetailBeforeActivity"
-            android:exported="true" />
+            android:exported="false" />
         <activity
             android:name=".feature.write.WriteActivity"
-            android:exported="true" />
+            android:exported="false" />
         <activity
             android:name=".feature.storage.worrytemplate.WorryTemplateActivity"
-            android:exported="true" />
+            android:exported="false" />
         <activity
             android:name=".feature.detail.DetailAfterActivity"
-            android:exported="true"
+            android:exported="false"
             android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".feature.mypage.MypageActivity"
-            android:exported="true" />
+            android:exported="false" />
         <activity
             android:name=".feature.mypage.WebViewActivity"
-            android:exported="true" />
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/hara/kaera/application/Notification.kt
+++ b/app/src/main/java/com/hara/kaera/application/Notification.kt
@@ -32,6 +32,7 @@ class Notification(
 
         return with(context) {
             NotificationCompat.Builder(this, getString(R.string.project_id))
+                //TODO 아이콘 교체
                 .setSmallIcon(R.drawable.gem_blue_l)
                 .setContentTitle(title)
                 .setContentText(body)

--- a/app/src/main/java/com/hara/kaera/feature/MainActivity.kt
+++ b/app/src/main/java/com/hara/kaera/feature/MainActivity.kt
@@ -7,8 +7,8 @@ import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.app.ActivityCompat
 import androidx.activity.viewModels
+import androidx.core.app.ActivityCompat
 import androidx.fragment.app.Fragment
 import com.hara.kaera.R
 import com.hara.kaera.databinding.ActivityMainBinding
@@ -31,7 +31,6 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     private val homeFragment = HomeFragment()
     private val storageFragment = StorageFragment()
     private val viewModel by viewModels<HomeViewModel>()
-
 
     private lateinit var launcher: ActivityResultLauncher<Array<String>>
 
@@ -57,9 +56,6 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         super.onCreate(savedInstanceState)
         setPermission()
         this.onBackPressedDispatcher.addCallback(this, callback)
-        //TODO 원석이 가득찰 경우 DialogFullStoneFragment().show(supportFragmentManager, "full_stone")
-        //이거 수정하려면 HomeFragment에 있는 뷰모델을 액티비티에서 생성되도록 옮기고
-        // 내부 아이템이 12면 바텀내비 부분에서 조건문으로 분기처리 해줘야 되겠네
         registerBottomNav()
     }
 
@@ -121,7 +117,8 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
                                 Intent(applicationContext, WriteActivity::class.java).apply {
                                     putExtra("action", "write")
                                 }
-                            )                        }
+                            )
+                        }
                         return@setOnItemSelectedListener false
                     }
 

--- a/app/src/main/java/com/hara/kaera/feature/MainActivity.kt
+++ b/app/src/main/java/com/hara/kaera/feature/MainActivity.kt
@@ -1,8 +1,13 @@
 package com.hara.kaera.feature
 
+import android.Manifest
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.app.ActivityCompat
 import androidx.activity.viewModels
 import androidx.fragment.app.Fragment
 import com.hara.kaera.R
@@ -14,7 +19,6 @@ import com.hara.kaera.feature.home.HomeFragment
 import com.hara.kaera.feature.home.HomeViewModel
 import com.hara.kaera.feature.storage.StorageFragment
 import com.hara.kaera.feature.util.Constant
-import com.hara.kaera.feature.util.PermissionRequestDelegator
 import com.hara.kaera.feature.util.makeToast
 import com.hara.kaera.feature.util.navigateTo
 import com.hara.kaera.feature.util.stringOf
@@ -29,12 +33,13 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     private val viewModel by viewModels<HomeViewModel>()
 
 
+    private lateinit var launcher: ActivityResultLauncher<Array<String>>
+
     private var time: Long = 0
     private val callback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
             if (System.currentTimeMillis() - time >= 2000) {
                 time = System.currentTimeMillis()
-                Timber.e("home backpress")
                 KaeraSnackBar.make(
                     view = binding.root,
                     message = baseContext.stringOf(R.string.main_backpress),
@@ -50,15 +55,54 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (PermissionRequestDelegator(this).checkPermissions(PermissionRequestDelegator.PLACE.HOME) == true) {
-            binding.root.makeToast("원활한 서비스를 위해서 알림을 활성화 해 주세요!")
-        }
+        setPermission()
         this.onBackPressedDispatcher.addCallback(this, callback)
         //TODO 원석이 가득찰 경우 DialogFullStoneFragment().show(supportFragmentManager, "full_stone")
         //이거 수정하려면 HomeFragment에 있는 뷰모델을 액티비티에서 생성되도록 옮기고
         // 내부 아이템이 12면 바텀내비 부분에서 조건문으로 분기처리 해줘야 되겠네
         registerBottomNav()
     }
+
+    private fun setPermission() {
+
+        launcher =
+            registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+                val deniedPermissionList = permissions.filter { !it.value }.map { it.key }
+                when {
+                    deniedPermissionList.isNotEmpty() -> {
+                        val map = deniedPermissionList.groupBy { permission ->
+                            if (shouldShowRequestPermissionRationale(permission)) "denied" else "explained"
+                        }
+                        map["denied"]?.let {
+                            // 최초거절 케이스 (앱 최초 설치이후 한번만 타게 됨)
+                            binding.root.makeToast("원활한 서비스 이용을 위해서 알림권한을 허용해주세요!")
+                        }
+                        map["explained"]?.let {
+                            //권한 영구 거절( 2번째 거절 이후 ) 메인에서는 아무런 동작도 안함
+                        }
+                    }
+
+                    else -> Unit
+                }
+            }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
+                Timber.e("ration")
+
+                //TODO rationale dialog
+                ActivityCompat.requestPermissions(
+                    this,
+                    arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                    1
+                )
+            } else {
+                launcher.launch(arrayOf(Manifest.permission.POST_NOTIFICATIONS))
+            }
+
+        }
+    }
+
 
     private fun registerBottomNav() {
         with(binding.bottomNav) {

--- a/app/src/main/java/com/hara/kaera/feature/mypage/MypageActivity.kt
+++ b/app/src/main/java/com/hara/kaera/feature/mypage/MypageActivity.kt
@@ -3,8 +3,13 @@ package com.hara.kaera.feature.mypage
 import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -31,15 +36,15 @@ import javax.inject.Inject
 class MypageActivity : BindingActivity<ActivityMypageBinding>(R.layout.activity_mypage) {
 
     private val myPageViewModel by viewModels<MypageViewModel>()
-    private lateinit var permissionRequestDelegator: PermissionRequestDelegator
+
+    private lateinit var launcher: ActivityResultLauncher<Array<String>>
 
     @Inject
     lateinit var kaKaoLoginClient: KaKaoLoginClient
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        permissionRequestDelegator = PermissionRequestDelegator(this)
         setClickListener()
-        grantPermission()
+        setNotification()
         collectFlow()
     }
 
@@ -55,52 +60,50 @@ class MypageActivity : BindingActivity<ActivityMypageBinding>(R.layout.activity_
         }
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-//            if(!myPageViewModel.permissionGranted.value)
-//            revokeSelfPermissionOnKill(Manifest.permission.POST_NOTIFICATIONS)
-//        }
+    override fun onResume() {
+        super.onResume()
+        // 시스템 설정창에서 권한 허용하고 들어온 경우 / 다이얼로그를 통해서 허용한 경우 뷰 갱신
+        notificationView()
     }
 
     private fun grantPermission() {
 
-        if (ContextCompat.checkSelfPermission(
-                baseContext,
-                Manifest.permission.POST_NOTIFICATIONS
-            ) == PackageManager.PERMISSION_GRANTED
-        ) {
-            binding.tvAllow.visible(false)
-            binding.tbAlertToggle.visible(true)
-        } else {
-            binding.tvAllow.visible(true)
-            binding.tbAlertToggle.visible(false)
-        }
+                    else -> {
+                        //권한이 허가 되었을때
+                        notificationView()
+                    }
+                }
+            }
 
         binding.tbAlertToggle.onSingleClick {
-            if (ContextCompat.checkSelfPermission(
-                    baseContext,
-                    Manifest.permission.POST_NOTIFICATIONS
-                ) == PackageManager.PERMISSION_GRANTED
-            ) {
+            // 토글 온 오프는 서버에서의 FCM 활성화 유무에 달림
+            if (false) {
                 // 여기서 서버에 fcm 토큰을 삭제하고 체크하고 등록하는 로직이 필요함!
                 // 안드로이드에서 즉시 프로그래밍적으로 알림권한을 삭제하거나 비활성화 시키는 방법은 없음(앱의 재시작이 필요)
                 // 따라서 알림권한이 잇는가 -> 그다음 fcm 토큰이서버에 등록되어 있는가? 둘다 true이면 토클이 isChecked true
                 // 하나라도 false일 경우 isCheceked가 false로 될 필요가 있다 따라서.
                 // 서버측에 fcm 관련 api가 필요하다
-                Timber.e("ture_check")
-//                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-//                    myPageViewModel.permissionChanged(
-//                        ContextCompat.checkSelfPermission(baseContext, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
-//                    )
-//                }
+                // FCM 활성화
             } else {
                 // FCM 비활성화
             }
         }
         binding.tvAllow.setOnClickListener {
-            Timber.e("allow")
-            permissionRequestDelegator.checkPermissions()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
+                    Timber.e("ration")
+
+                    //TODO rationale dialog
+                    ActivityCompat.requestPermissions(
+                        this,
+                        arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                        1
+                    )
+                } else {
+                    launcher.launch(arrayOf(Manifest.permission.POST_NOTIFICATIONS))
+                }
+
+            }
         }
     }
 
@@ -169,6 +172,17 @@ class MypageActivity : BindingActivity<ActivityMypageBinding>(R.layout.activity_
                     }
                 }.show(supportFragmentManager, "unregister")
             }
+        }
+    }
+
+    private fun notificationView() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val granted = ContextCompat.checkSelfPermission(
+                baseContext,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+            binding.tvAllow.visible(!granted)
+            binding.tbAlertToggle.visible(granted)
         }
     }
 

--- a/app/src/main/java/com/hara/kaera/feature/mypage/MypageActivity.kt
+++ b/app/src/main/java/com/hara/kaera/feature/mypage/MypageActivity.kt
@@ -21,6 +21,7 @@ import com.hara.kaera.feature.util.PermissionRequestDelegator
 import com.hara.kaera.feature.util.increaseTouchSize
 import com.hara.kaera.feature.util.makeToast
 import com.hara.kaera.feature.util.onSingleClick
+import com.hara.kaera.feature.util.visible
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -64,6 +65,18 @@ class MypageActivity : BindingActivity<ActivityMypageBinding>(R.layout.activity_
 
     private fun grantPermission() {
 
+        if (ContextCompat.checkSelfPermission(
+                baseContext,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+        ) {
+            binding.tvAllow.visible(false)
+            binding.tbAlertToggle.visible(true)
+        } else {
+            binding.tvAllow.visible(true)
+            binding.tbAlertToggle.visible(false)
+        }
+
         binding.tbAlertToggle.onSingleClick {
             if (ContextCompat.checkSelfPermission(
                     baseContext,
@@ -82,9 +95,12 @@ class MypageActivity : BindingActivity<ActivityMypageBinding>(R.layout.activity_
 //                    )
 //                }
             } else {
-                Timber.e("false_check")
-                permissionRequestDelegator.checkPermissions()
+                // FCM 비활성화
             }
+        }
+        binding.tvAllow.setOnClickListener {
+            Timber.e("allow")
+            permissionRequestDelegator.checkPermissions()
         }
     }
 

--- a/app/src/main/java/com/hara/kaera/feature/splash/StartViewModel.kt
+++ b/app/src/main/java/com/hara/kaera/feature/splash/StartViewModel.kt
@@ -118,7 +118,6 @@ class StartViewModel @Inject constructor(
                 it.collect { apiResult ->
                     when (apiResult) {
                         is ApiResult.Success -> {
-                            Timber.e("callUpdatedAccessToken : ${apiResult.data}")
                             kotlin.runCatching {
                                 loginRepository.updateAccessToken(accessToken = apiResult.data)
                             }.onSuccess {
@@ -129,9 +128,8 @@ class StartViewModel @Inject constructor(
                         }
 
                         is ApiResult.Error -> {
-                            Timber.e("callUpdatedAccessToken : ${apiResult.error}")
                             // 토큰이 유효하지 않거나 만료된 경우
-                            // TODO 스플래시일 경우 로그인 액티비티를 이동하지 않으면서
+                            // 스플래시일 경우 로그인 액티비티를 이동하지 않으면서
                             // kakaoclient를 이용하여 로그인 후 OAuth토큰을 기반으로 JWT를 새로 받아와야함
                             when (apiResult.error) {
                                 is ErrorType.Api.BadRequest -> {

--- a/app/src/main/res/layout/activity_mypage.xml
+++ b/app/src/main/res/layout/activity_mypage.xml
@@ -121,6 +121,7 @@
                     android:id="@+id/cl_push_alert"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
                     android:paddingVertical="20dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
@@ -146,9 +147,11 @@
                         android:text="@string/mypage_noti_allow"
                         android:textAppearance="@style/h_body2_r16"
                         android:textColor="@color/blue"
-                        app:layout_constraintBottom_toBottomOf="@id/tv_alert"
+                        android:visibility="gone"
+                        app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toTopOf="@+id/tv_alert" />
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:visibility="visible" />
 
                     <androidx.appcompat.widget.SwitchCompat
                         android:id="@+id/tb_alert_toggle"

--- a/app/src/main/res/layout/activity_mypage.xml
+++ b/app/src/main/res/layout/activity_mypage.xml
@@ -122,6 +122,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:paddingVertical="20dp"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/tv_alert_setting">
 
@@ -136,6 +137,18 @@
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />
+
+                    <TextView
+                        android:id="@+id/tv_allow"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="16dp"
+                        android:text="@string/mypage_noti_allow"
+                        android:textAppearance="@style/h_body2_r16"
+                        android:textColor="@color/blue"
+                        app:layout_constraintBottom_toBottomOf="@id/tv_alert"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="@+id/tv_alert" />
 
                     <androidx.appcompat.widget.SwitchCompat
                         android:id="@+id/tb_alert_toggle"
@@ -152,7 +165,8 @@
                         app:layout_constraintTop_toTopOf="@+id/tv_alert"
                         app:thumbTint="@drawable/thumb_tint"
                         app:track="@drawable/switch_track"
-                        app:trackTint="@drawable/track_tint" />
+                        app:trackTint="@drawable/track_tint"
+                        tools:visibility="gone" />
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <View

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,7 @@
     <string name="mypage_title">마이페이지</string>
     <string name="mypage_alert_setting">알림설정</string>
     <string name="mypage_push_alert">Push 알림</string>
+    <string name="mypage_noti_allow">권한 허용</string>
     <string name="mypage_tos">이용 약관</string>
     <string name="mypage_info">정보</string>
     <string name="mypage_kaera_guide">캐라 사용설명서</string>


### PR DESCRIPTION
<!-- 🔥 Assignee, Label, Reviewer 설정!!!🔥 -->

## 📒 이슈

- Resolved: #118 

## 🔥 작업 내용

- 알림권한 플로우 수정하였습니다. 
기존에는 토글버튼으로 권한을 조정하였다면, 이제는 권한 부여를 받은후 토글버튼을 통해서 FCM을 활성/비활성 시키는 형태입니다. 
- exported 중에서 불필요한 부분은 false처리 하였습니다.


## 📱실행결과

https://github.com/TeamHARA/KAERA_Android/assets/70648111/34b9df3f-a95f-4b66-8f54-f3bfc7e2573c


https://github.com/TeamHARA/KAERA_Android/assets/70648111/652f62da-710d-4a88-9518-efeb6da16e5f



<!-- gif or mp4. gif는 [https://ezgif.com/](https://ezgif.com/) 활용! 용량제한 10MB넘어가면 카톡으로.. -->
